### PR TITLE
Fix case of schema keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+output.json
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/dummy_bq.py
+++ b/dummy_bq.py
@@ -53,20 +53,20 @@ def mockdata(t):
 def generate(schema):
     dic = {}
     for column in schema:
-        if column['MODE'] == 'REPEAT':
-            if column['TYPE'] == 'RECORD':
-                dic[column['NAME']] = [generate(column['FIELDS']) for i in range(0, random.randrange(MAX_REPEAT_NUM) + 1)]
+        if column['mode'] == 'REPEAT':
+            if column['type'] == 'RECORD':
+                dic[column['name']] = [generate(column['FIELDS']) for i in range(0, random.randrange(MAX_REPEAT_NUM) + 1)]
             else:
-                dic[column['NAME']] = [mockdata(column['TYPE']) for i in range(0, random.randrange(MAX_REPEAT_NUM) + 1)]
+                dic[column['name']] = [mockdata(column['type']) for i in range(0, random.randrange(MAX_REPEAT_NUM) + 1)]
         else:
-            if column['MODE'] == 'NULLABLE':
+            if column['mode'] == 'NULLABLE':
                 if random.randint(0, 1):
                     continue
 
-            if column['TYPE'] == 'RECORD':
-                dic[column['NAME']] = generate(column['FIELDS'])
+            if column['type'] == 'RECORD':
+                dic[column['name']] = generate(column['FIELDS'])
             else:
-                dic[column['NAME']] = mockdata(column['TYPE'])
+                dic[column['name']] = mockdata(column['type'])
     return dic
 
 
@@ -78,7 +78,7 @@ def to_upper(schema):
             if isinstance(k, str):
                 k = k.upper()
             if isinstance(v, str):
-                if k != 'NAME':
+                if k != 'name':
                     v = v.upper()
             if isinstance(v, list):
                 v = to_upper(v)


### PR DESCRIPTION
Before this change, `python dummy_bq.py example/flat.json` gives:
```
Traceback (most recent call last):
  File "dummy_bq.py", line 95, in <module>
    ojf.write(json.dumps(generate(schema)) + '\n')
  File "dummy_bq.py", line 56, in generate
    if column['MODE'] == 'REPEAT':
KeyError: 'MODE'
```
After this change, things work.